### PR TITLE
Different colors for heading levels

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -7,11 +7,11 @@
   --background-secondary-alt: #000000;
   --text-normal: #5dbcd2;
   --text-faint: #999999;
-  --text-title-h1: #5dbcd2;
-  --text-title-h2: #5dbcd2;
-  --text-title-h3: #5dbcd2;
-  --text-title-h4: #5dbcd2;
-  --text-title-h5: #5dbcd2;
+  --text-title-h1: #f94144;
+  --text-title-h2: #f3722c;
+  --text-title-h3: #f8961e;
+  --text-title-h4: #f9c74f;
+  --text-title-h5: #90be6d;
   --text-title-h6: #5dbcd2;
   --text-link: #99ff99;
   --text-a: #d669bc;


### PR DESCRIPTION
Cybertron is definitely my favorite theme for Obsidian, especially the horizontal scrolling feature!

But something I love about other themes is the increased readability of different heading colors. 
I'd love to see your own take on heading colors, but thought I'd open a PR just to get the ball rolling.

![image](https://user-images.githubusercontent.com/23033765/91310335-bf072200-e77f-11ea-83df-09b7d8501c27.png)
