### PR TITLE
Fixes settings page on iOS

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1415,7 +1415,7 @@ color: var(--text-normal);
 }
 .modal.mod-settings {
   max-width: 1000px;
-  width: 900vw;
+  width: 100vw;
   height: 90vh;
 }
 


### PR DESCRIPTION
The settings page was broken on mobile (iPhone). This should fix the problem.
The solution has been tested on iPhone 11 Pro running iOS 15 beta 3