### PR TITLE
Updated obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1415,7 +1415,7 @@ color: var(--text-normal);
 }
 .modal.mod-settings {
   max-width: 1000px;
-  width: 100vw;
+  width: 90vw;
   height: 90vh;
 }
 


### PR DESCRIPTION
Fixes #13 iPadOS obsidian settings menu being obscured in split view. Appears to have fixed issue.